### PR TITLE
Rename pm2-docker to pm2-runtime

### DIFF
--- a/example-app/Dockerfile
+++ b/example-app/Dockerfile
@@ -12,4 +12,4 @@ RUN npm install --production
 # Show current folder structure in logs
 RUN ls -al -R
 
-CMD [ "pm2-docker", "start", "pm2.json" ]
+CMD [ "pm2-runtime", "start", "pm2.json" ]

--- a/tags/4/alpine/Dockerfile
+++ b/tags/4/alpine/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/4/debian/jessie/Dockerfile
+++ b/tags/4/debian/jessie/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/4/debian/slim/Dockerfile
+++ b/tags/4/debian/slim/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/4/debian/stretch/Dockerfile
+++ b/tags/4/debian/stretch/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/4/debian/wheezy/Dockerfile
+++ b/tags/4/debian/wheezy/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/6/alpine/Dockerfile
+++ b/tags/6/alpine/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/6/debian/jessie/Dockerfile
+++ b/tags/6/debian/jessie/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/6/debian/slim/Dockerfile
+++ b/tags/6/debian/slim/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/6/debian/stretch/Dockerfile
+++ b/tags/6/debian/stretch/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/6/debian/wheezy/Dockerfile
+++ b/tags/6/debian/wheezy/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/8/alpine/Dockerfile
+++ b/tags/8/alpine/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/8/debian/jessie/Dockerfile
+++ b/tags/8/debian/jessie/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/8/debian/slim/Dockerfile
+++ b/tags/8/debian/slim/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/8/debian/stretch/Dockerfile
+++ b/tags/8/debian/stretch/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/8/debian/wheezy/Dockerfile
+++ b/tags/8/debian/wheezy/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/latest/alpine/Dockerfile
+++ b/tags/latest/alpine/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/latest/debian/jessie/Dockerfile
+++ b/tags/latest/debian/jessie/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/latest/debian/slim/Dockerfile
+++ b/tags/latest/debian/slim/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/latest/debian/stretch/Dockerfile
+++ b/tags/latest/debian/stretch/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/latest/debian/wheezy/Dockerfile
+++ b/tags/latest/debian/wheezy/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install pm2 -g
 EXPOSE 80 443 43554
 
 # Start pm2.json process file
-CMD ["pm2-docker", "start", "pm2.json"]
+CMD ["pm2-runtime", "start", "pm2.json"]


### PR DESCRIPTION
# Changes
In the latest pm2 release, pm2-docker has now been aliased to pm2-runtime
See https://github.com/Unitech/pm2/commit/cca21add3a3068386b766b61a17e9e1838bbee2a