### PR TITLE
Add Debian buster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 env:
   - TEST_TAGS='latest-alpine'
   - TEST_TAGS='latest-stretch'
+  - TEST_TAGS='latest-buster'
   - TEST_TAGS='latest-jessie'
   - TEST_TAGS='latest-slim'
   - TEST_TAGS='latest-wheezy'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ keymetrics/pm2:`8-alpine`|[Alpine](https://www.alpinelinux.org/about/)|[8-alpine
 keymetrics/pm2:`6-alpine`|[Alpine](https://www.alpinelinux.org/about/)|[6-alpine](tags/6/alpine/Dockerfile)
 keymetrics/pm2:`4-alpine`|[Alpine](https://www.alpinelinux.org/about/)|[4-alpine](tags/4/alpine/Dockerfile)
 **Image Name** | **Operating system** | **Dockerfile**
+keymetrics/pm2:`latest-buster`|[Debian Buster](https://wiki.debian.org/DebianBuster)|[latest-buster](tags/latest/buster/Dockerfile)
+keymetrics/pm2:`14-buster`|[Debian Buster](https://wiki.debian.org/DebianBuster)|[14-buster](tags/14/buster/Dockerfile)
+keymetrics/pm2:`12-buster`|[Debian Buster](https://wiki.debian.org/DebianBuster)|[12-buster](tags/12/buster/Dockerfile)
+keymetrics/pm2:`10-buster`|[Debian Buster](https://wiki.debian.org/DebianBuster)|[10-buster](tags/10/buster/Dockerfile)
+keymetrics/pm2:`8-buster`|[Debian Buster](https://wiki.debian.org/DebianBuster)|[8-buster](tags/8/buster/Dockerfile)
+**Image Name** | **Operating system** | **Dockerfile**
 keymetrics/pm2:`latest-stretch`|[Debian Stretch](https://wiki.debian.org/DebianStretch)|[latest-stretch](tags/latest/stretch/Dockerfile)
 keymetrics/pm2:`14-stretch`|[Debian Stretch](https://wiki.debian.org/DebianStretch)|[14-stretch](tags/14/stretch/Dockerfile)
 keymetrics/pm2:`12-stretch`|[Debian Stretch](https://wiki.debian.org/DebianStretch)|[12-stretch](tags/12/stretch/Dockerfile)

--- a/docker-tags.sh
+++ b/docker-tags.sh
@@ -13,10 +13,12 @@ self="$(basename "${BASH_SOURCE[0]}")"
 date=$(date +'%Y-%m-%d %H:%M:%S')
 
 declare -A versions
-versions['latest']='alpine|stretch|jessie|slim'
-versions['12']='alpine|stretch|jessie|slim'
-versions['10']='alpine|stretch|jessie|slim|wheezy'
-versions['8']='alpine|stretch|jessie|slim|wheezy'
+versions['latest']='alpine|stretch|buster|jessie|slim'
+versions['14']='alpine|stretch|buster|jessie|slim'
+versions['13']='alpine|stretch|buster|jessie|slim'
+versions['12']='alpine|stretch|buster|jessie|slim'
+versions['10']='alpine|stretch|buster|jessie|slim|wheezy'
+versions['8']='alpine|stretch|buster|jessie|slim|wheezy'
 versions['6']='alpine|stretch|jessie|slim|wheezy'
 versions['4']='alpine|stretch|jessie|slim|wheezy'
 

--- a/tags/10/buster/Dockerfile
+++ b/tags/10/buster/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10-buster
+LABEL maintainer="Keymetrics <contact@keymetrics.io>"
+
+# Install pm2
+RUN npm install pm2 -g
+
+# Expose ports needed to use Keymetrics.io
+EXPOSE 80 443 43554
+
+# Start pm2.json process file
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/12/buster/Dockerfile
+++ b/tags/12/buster/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12-buster
+LABEL maintainer="Keymetrics <contact@keymetrics.io>"
+
+# Install pm2
+RUN npm install pm2 -g
+
+# Expose ports needed to use Keymetrics.io
+EXPOSE 80 443 43554
+
+# Start pm2.json process file
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/13/buster/Dockerfile
+++ b/tags/13/buster/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:13-buster
+LABEL maintainer="Keymetrics <contact@keymetrics.io>"
+
+# Install pm2
+RUN npm install pm2 -g
+
+# Expose ports needed to use Keymetrics.io
+EXPOSE 80 443 43554
+
+# Start pm2.json process file
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/14/buster/Dockerfile
+++ b/tags/14/buster/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14-buster
+LABEL maintainer="Keymetrics <contact@keymetrics.io>"
+
+# Install pm2
+RUN npm install pm2 -g
+
+# Expose ports needed to use Keymetrics.io
+EXPOSE 80 443 43554
+
+# Start pm2.json process file
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/8/buster/Dockerfile
+++ b/tags/8/buster/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8-buster
+LABEL maintainer="Keymetrics <contact@keymetrics.io>"
+
+# Install pm2
+RUN npm install pm2 -g
+
+# Expose ports needed to use Keymetrics.io
+EXPOSE 80 443 43554
+
+# Start pm2.json process file
+CMD ["pm2-runtime", "start", "pm2.json"]

--- a/tags/latest/buster/Dockerfile
+++ b/tags/latest/buster/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:buster
+LABEL maintainer="Keymetrics <contact@keymetrics.io>"
+
+# Install pm2
+RUN npm install pm2 -g
+
+# Expose ports needed to use Keymetrics.io
+EXPOSE 80 443 43554
+
+# Start pm2.json process file
+CMD ["pm2-runtime", "start", "pm2.json"]


### PR DESCRIPTION
> https://www.debian.org/releases/stretch/
> Debian 9 has been superseded by Debian 10 (buster). Security updates have been discontinued as of July 6th, 2020.

To keep PM2 running with the latest security patches, this PR adds Node 8 thru 14 running on buster.